### PR TITLE
Fix consumption stats month comparison

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: "weekly"
       timezone: "Europe/Berlin"
+    labels:
+      - "dependencies"
     assignees:
       - "maxstue"
 
@@ -13,6 +15,8 @@ updates:
     schedule:
       interval: "weekly"
       timezone: "Europe/Berlin"
+    labels:
+      - "dependencies"
     assignees:
       - "maxstue"
 
@@ -21,5 +25,7 @@ updates:
     schedule:
       interval: "weekly"
       timezone: "Europe/Berlin"
+    labels:
+      - "dependencies"
     assignees:
       - "maxstue"

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -2,8 +2,6 @@ name: Deployment
 
 on:
   workflow_dispatch:
-  push:
-    branches: ['main']
 permissions:
   contents: read
 

--- a/apps/api/src/Application/Consumptions/GetStats/GetStatsConsumptions.cs
+++ b/apps/api/src/Application/Consumptions/GetStats/GetStatsConsumptions.cs
@@ -8,13 +8,9 @@ namespace Kijk.Application.Consumptions.GetStats;
 /// Handler for getting consumption statistics.
 /// It returns the resource usage statistics for the selected year and month.
 /// The statistics include the total, average, min, and max values for the selected year.
-/// If the selected year or month is the current year or month, the comparison year or month is the previous year or month.
-/// If the selected year or month is in the past, the comparison year or month is the current year or month.
-/// The statistics for the comparison year and month are calculated based on the selected year and month.
 /// The comparison year is the previous year if the selected year is the current year.
 /// The comparison year is the current year if the selected year is in the past.
-/// The comparison month is the previous month if the selected month is the current month.
-/// The comparison month is the current month if the selected month is in the past.
+/// The comparison month is the current month unless the selected month is the current month.
 /// </summary>
 public class GetStatsConsumptionsHandler(IAppDbContext dbContext, CurrentUser currentUser) : IHandler
 {
@@ -27,6 +23,7 @@ public class GetStatsConsumptionsHandler(IAppDbContext dbContext, CurrentUser cu
             .AsNoTracking()
             .ToListAsync(cancellationToken);
 
+        var selectedMonth = DateTime.ParseExact(month, "MMMM", CultureInfo.InvariantCulture).Month;
         var comparisonYear = GetComparisonYear(year);
         var comparisonYearUsages = await dbContext.Consumptions
             .Where(x => x.HouseholdId == currentUser.ActiveHouseholdId)
@@ -37,9 +34,19 @@ public class GetStatsConsumptionsHandler(IAppDbContext dbContext, CurrentUser cu
             .Select(g => new { g.Key.TypeName, g.Key.TypeUnit, g.Key.TypeColor, Usages = g.ToList() })
             .ToListAsync(cancellationToken);
 
+        var comparisonMonth = GetComparisonMonthPeriod(year, selectedMonth);
+        var comparisonMonthUsages = await dbContext.Consumptions
+            .Include(x => x.Resource)
+            .Where(x => x.HouseholdId == currentUser.ActiveHouseholdId)
+            .Where(x => x.Date.Value.Year == comparisonMonth.Year)
+            .Where(x => x.Date.Value.Month == comparisonMonth.Month)
+            .AsNoTracking()
+            .ToListAsync(cancellationToken);
+
         var resources = selectedYearUsages
             .Select(x => new { TypeName = x.Resource.Name, TypeUnit = x.Resource.Unit, TypeColor = x.Resource.Color })
             .Concat(comparisonYearUsages.Select(x => new { x.TypeName, x.TypeUnit, x.TypeColor }))
+            .Concat(comparisonMonthUsages.Select(x => new { TypeName = x.Resource.Name, TypeUnit = x.Resource.Unit, TypeColor = x.Resource.Color }))
             .DistinctBy(x => new { x.TypeName, x.TypeUnit })
             .ToList();
 
@@ -50,7 +57,7 @@ public class GetStatsConsumptionsHandler(IAppDbContext dbContext, CurrentUser cu
                     ?.Usages ?? [];
 
                 return CalculateStats(resource.TypeName, resource.TypeUnit, resource.TypeColor, year, month, selectedYearUsages,
-                    comparisonUsages);
+                    comparisonUsages, comparisonMonthUsages);
             })
             .ToList();
 
@@ -83,49 +90,30 @@ public class GetStatsConsumptionsHandler(IAppDbContext dbContext, CurrentUser cu
         return selectedYear;
     }
 
-    /// <summary>
-    /// Get the comparison month based on the selected year and month.
-    /// If the selected year is the current year, the comparison month is the previous month.
-    /// If the selected year is in the past, the comparison month is the current month.
-    /// </summary>
-    /// <param name="selectedYear"></param>
-    /// <param name="selectedMonth"></param>
-    /// <returns></returns>
-    private static int GetComparisonMonth(int selectedYear, int selectedMonth)
+    private static (int Year, int Month) GetComparisonMonthPeriod(int selectedYear, int selectedMonth)
     {
         var currentYear = DateTime.UtcNow.Year;
         var currentMonth = DateTime.UtcNow.Month;
-        // compare to current month if selected year is current year
-        if (selectedYear == currentYear)
-        {
-            // compare to previous month if selected month is current month
-            if (selectedMonth == currentMonth)
-            {
-                return currentMonth - 1;
-            }
 
-            // compare to current month if selected month is in the past
-            if (selectedMonth < currentMonth)
-            {
-                return currentMonth;
-            }
+        if (selectedYear == currentYear && selectedMonth == currentMonth)
+        {
+            return currentMonth == 1 ? (currentYear - 1, 12) : (currentYear, currentMonth - 1);
         }
 
-        // compare to current month if selected year is in the future
-        return currentMonth;
+        return (currentYear, currentMonth);
     }
 
     private static ConsumptionStatsResponse CalculateStats(string type, string unit, string color, int selectedYear, string selectedMonth,
-        IList<Domain.Entities.Consumption> selectedYearEnergies, IList<Domain.Entities.Consumption> comparisonYearEnergies)
+        IList<Domain.Entities.Consumption> selectedYearEnergies, IList<Domain.Entities.Consumption> comparisonYearEnergies,
+        IList<Domain.Entities.Consumption> comparisonMonthEnergies)
     {
         var selectedMonthInt = DateTime.ParseExact(selectedMonth, "MMMM", CultureInfo.InvariantCulture).Month;
-        var comparisonMonthInt = GetComparisonMonth(selectedYear, selectedMonthInt);
 
         var selectedYearEnergiesByType = selectedYearEnergies.Where(x => x.Resource.Name == type && x.Resource.Unit == unit).ToList();
         var comparisonYearEnergiesByType = comparisonYearEnergies.Where(x => x.Resource.Name == type && x.Resource.Unit == unit).ToList();
+        var comparisonMonthEnergiesByType = comparisonMonthEnergies.Where(x => x.Resource.Name == type && x.Resource.Unit == unit).ToList();
 
         var selectedMonthEnergies = selectedYearEnergiesByType.Where(x => x.Date.Value.Month == selectedMonthInt).ToList();
-        var comparisonMonthEnergies = comparisonYearEnergiesByType.Where(x => x.Date.Value.Month == comparisonMonthInt).ToList();
 
         var yearTotal = selectedYearEnergiesByType.Sum(x => x.Value);
         var yearAverage = selectedYearEnergiesByType.Count == 0 ? yearTotal : yearTotal / selectedYearEnergiesByType.Count;
@@ -135,7 +123,7 @@ public class GetStatsConsumptionsHandler(IAppDbContext dbContext, CurrentUser cu
         var compYearTotal = comparisonYearEnergiesByType.Sum(x => x.Value);
         var compYearDiff = CalculateYearDiff(selectedYear, yearTotal, compYearTotal);
 
-        var compMonthTotal = comparisonMonthEnergies.Sum(x => x.Value);
+        var compMonthTotal = comparisonMonthEnergiesByType.Sum(x => x.Value);
         var selectedMonthTotal = selectedMonthEnergies.Sum(x => x.Value);
         var compMonthDiff = CalculateMonthDiff(selectedYear, selectedMonthInt, selectedMonthTotal, compMonthTotal);
 
@@ -147,7 +135,9 @@ public class GetStatsConsumptionsHandler(IAppDbContext dbContext, CurrentUser cu
     {
         var currentYear = DateTime.UtcNow.Year;
 
-        return selectedYear == currentYear ? selectedYearTotal - compYearTotal : compYearTotal - selectedYearTotal;
+        return selectedYear == currentYear
+            ? selectedYearTotal - compYearTotal
+            : compYearTotal - selectedYearTotal;
     }
 
     private static decimal CalculateMonthDiff(int selectedYear, int selectedMonth, decimal selectedMonthTotal, decimal compMonthTotal)

--- a/apps/client/src/app/consumptions/stats.tsx
+++ b/apps/client/src/app/consumptions/stats.tsx
@@ -4,14 +4,24 @@ import { getRouteApi } from '@tanstack/react-router';
 
 import { consumptionsStatsQueryOptions } from '@/shared/api/consumptions/options';
 import { ResourceUnit } from '@/shared/components/resources-unit';
+import type { Months } from '@/shared/utils/months';
+import { getMonthFromDate } from '@/shared/utils/months';
 
 const Route = getRouteApi('/_protected/consumptions');
+
+function getComparisonLabel(selectedYear: number, selectedMonth: Months) {
+  const now = new Date();
+  const isCurrentMonth = selectedYear === now.getFullYear() && selectedMonth === getMonthFromDate(now);
+
+  return isCurrentMonth ? 'from last month' : 'compared to current month';
+}
 
 export default function ConsumptionStats() {
   const searchParameters = Route.useSearch();
 
   const selectedYear = searchParameters.year;
   const selectedMonth = searchParameters.month;
+  const comparisonLabel = getComparisonLabel(selectedYear, selectedMonth);
 
   const { data } = useSuspenseQuery(consumptionsStatsQueryOptions(selectedYear, selectedMonth));
 
@@ -40,7 +50,9 @@ export default function ConsumptionStats() {
                 <div className='text-2xl font-bold'>
                   {item.monthTotal} <ResourceUnit type={item.resource} />
                 </div>
-                <p className='text-muted-foreground text-xs'>{item.comparisonMonthDiff} from last month</p>
+                <p className='text-muted-foreground text-xs'>
+                  {item.comparisonMonthDiff} {comparisonLabel}
+                </p>
               </CardContent>
             </Card>
           ))}


### PR DESCRIPTION
## Summary

- compare selected non-current months against the actual current calendar month in backend stats
- keep current-month stats comparing against the previous calendar month
- update the stats card copy so the comparison text matches the selected month context
- make the deployment workflow manual-only to avoid release spam from dependency maintenance
- label Dependabot PRs with `dependencies`

## Root cause

The stats handler used a single comparison-year data set for both year and month comparisons. That meant the month comparison could read from the wrong year/month and the UI text always said `from last month`, even when the selected month was being compared to the current month.

The deployment workflow also still ran on pushes to `main`, so merging many small Dependabot PRs could trigger repeated production release runs.

## Release process update

- `deployment.yml` now runs only through `workflow_dispatch`
- Dependabot PRs for GitHub Actions, npm, and NuGet are labeled `dependencies`
- Linear docs were updated:
  - [Release Process](https://linear.app/justmax/document/release-process-563ce9397fc5)
  - [Operations](https://linear.app/justmax/document/operations-5405a97dcb1b)

## Validation

- `dotnet build apps/api/Kijk.slnx -c Release`
- `dotnet format apps/api/Kijk.slnx --verify-no-changes --exclude '**/Migrations/'`
- `pnpm --filter kijk-client typecheck`
- `pnpm --filter kijk-client fmt`
- `pnpm --filter kijk-client lint`
- `pnpm dlx react-doctor@latest . --verbose --diff` (100/100)
- `pnpm dlx fallow audit --format json --quiet --explain` (passed for new findings; inherited dead-code findings remain)
- `pnpm run lint:staged` (no staged files matched configured tasks for the YAML-only update)

Refs KIJK-307
