### PR TITLE
feat(auth): integrate official Clerk backend SDK

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ dotnet ef database update                   # creates/updates DB schema
 ```json
 "Auth": {
   "Authority": "<your Clerk URL>",
-  "AuthorizedParty": "http://localhost:5004"
+  "AuthorizedParties": ["http://localhost:5004"]
 }
 ```
 

--- a/apps/api/Directory.Packages.props
+++ b/apps/api/Directory.Packages.props
@@ -4,7 +4,6 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <MicrosoftAspNetCoreVersion>10.0.9</MicrosoftAspNetCoreVersion>
     <MicrosoftEntityFrameworkCoreVersion>10.0.9</MicrosoftEntityFrameworkCoreVersion>
-    <MicrosoftIdentityWebVersion>4.12.2</MicrosoftIdentityWebVersion>
     <AspNetCoreHealthChecksVersion>9.0.0</AspNetCoreHealthChecksVersion>
     <SentryVersion>6.6.0</SentryVersion>
     <HumanizerVersion>3.0.10</HumanizerVersion>
@@ -20,10 +19,8 @@
     <PackageVersion Include="AspNetCore.HealthChecks.UI.Client" Version="$(AspNetCoreHealthChecksVersion)" />
     <PackageVersion Include="AspNetCore.HealthChecks.NpgSql" Version="$(AspNetCoreHealthChecksVersion)" />
     <!-- Auth -->
-    <PackageVersion Include="Microsoft.Identity.Web" Version="$(MicrosoftIdentityWebVersion)" />
-    <PackageVersion Include="Microsoft.Identity.Web.DownstreamApi" Version="$(MicrosoftIdentityWebVersion)" />
+    <PackageVersion Include="Clerk.BackendAPI" Version="2.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MicrosoftAspNetCoreVersion)" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="$(MicrosoftAspNetCoreVersion)" />
     <!-- Database -->
     <PackageVersion Include="EFCore.NamingConventions" Version="10.0.1" />
     <PackageVersion Include="EntityFrameworkCore.Exceptions.PostgreSQL" Version="10.0.1" />

--- a/apps/api/src/Api/Api.csproj
+++ b/apps/api/src/Api/Api.csproj
@@ -20,9 +20,6 @@
         <PackageReference Include="Scalar.AspNetCore" />
         <!-- Auth -->
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer"/>
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect"/>
-        <PackageReference Include="Microsoft.Identity.Web"/>
-        <PackageReference Include="Microsoft.Identity.Web.DownstreamApi"/>
         <!-- Database -->
         <PackageReference Include="EFCore.NamingConventions"/>
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL"/>

--- a/apps/api/src/Api/appsettings.Development.json
+++ b/apps/api/src/Api/appsettings.Development.json
@@ -1,7 +1,9 @@
 {
   "Auth": {
     "Authority": "<from user-secrets>",
-    "AuthorizedParty": "<from user-secrets>"
+    "SecretKey": "<from user-secrets>",
+    "AuthorizedParties": ["<from user-secrets>"],
+    "ClockSkewInSeconds": 5
   },
   "ConnectionStrings": {
     "DefaultConnection": "<from user-secrets>"

--- a/apps/api/src/Api/appsettings.json
+++ b/apps/api/src/Api/appsettings.json
@@ -1,7 +1,9 @@
 {
   "Auth": {
     "Authority": "<from user-secrets or environment variable>",
-    "AuthorizedParty": "<from user-secrets or environment variable>"
+    "SecretKey": "<from user-secrets or environment variable>",
+    "AuthorizedParties": ["<from user-secrets or environment variable>"],
+    "ClockSkewInSeconds": 5
   },
   "OpenApi": {
     "Token": "<from user-secrets or environment variable>"

--- a/apps/api/src/Infrastructure/Auth/AuthOptions.cs
+++ b/apps/api/src/Infrastructure/Auth/AuthOptions.cs
@@ -11,5 +11,9 @@ public class AuthOptions : IConfigOptions
 
     public string Authority { get; set; } = null!;
 
-    public string AuthorizedParty { get; set; } = null!;
+    public string SecretKey { get; set; } = null!;
+
+    public string[] AuthorizedParties { get; set; } = [];
+
+    public int ClockSkewInSeconds { get; set; } = 5;
 }

--- a/apps/api/src/Infrastructure/DependencyInjection.cs
+++ b/apps/api/src/Infrastructure/DependencyInjection.cs
@@ -1,4 +1,6 @@
 using System.Security.Claims;
+using Clerk.BackendAPI;
+using Clerk.BackendAPI.Helpers.Jwks;
 using EntityFramework.Exceptions.PostgreSQL;
 using Kijk.Application.Abstractions.Persistence;
 using Kijk.Infrastructure.Auth;
@@ -29,6 +31,7 @@ public static class DependencyInjection
                 .AddCorsPolicy(configuration)
                 .AddTelemetry()
                 .AddLogging(configuration)
+                .AddClerkBackendApi()
                 .AddAuth(configuration);
 
         private IServiceCollection AddTelemetry()
@@ -102,15 +105,25 @@ public static class DependencyInjection
 
         private IServiceCollection AddAuth(IConfiguration configuration)
         {
+            var authOptions = configuration.GetSection(AuthOptions.SectionName).Get<AuthOptions>();
+            if (authOptions is null)
+            {
+                throw new NullException($"No AuthSettings found, {authOptions}");
+            }
+
+            var authorizedParties = authOptions.AuthorizedParties;
+
             services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
                 .AddJwtBearer(x =>
                 {
                     // Authority is the URL of your clerk instance
-                    x.Authority = configuration["Auth:Authority"];
+                    x.Authority = authOptions.Authority;
                     x.TokenValidationParameters = new()
                     {
                         // Disable audience validation as we aren't using it
-                        ValidateAudience = false, NameClaimType = ClaimTypes.NameIdentifier
+                        ValidateAudience = false,
+                        NameClaimType = ClaimTypes.NameIdentifier,
+                        ClockSkew = TimeSpan.FromSeconds(authOptions.ClockSkewInSeconds)
                     };
                     x.Events = new()
                     {
@@ -119,8 +132,8 @@ public static class DependencyInjection
                         {
                             var azp = context.Principal?.FindFirstValue("azp");
 
-                            // AuthorizedParty is the base URL of your frontend.
-                            if (string.IsNullOrEmpty(azp) || !azp.Equals(configuration["Auth:AuthorizedParty"], StringComparison.Ordinal))
+                            // AuthorizedParties contains the allowed base URLs of your frontends.
+                            if (string.IsNullOrEmpty(azp) || !authorizedParties.Contains(azp, StringComparer.Ordinal))
                             {
                                 context.Fail("AZP Claim is invalid or missing");
                             }
@@ -134,6 +147,17 @@ public static class DependencyInjection
 
             services.AddAuthorizationBuilder()
                 .AddPolicy(AppConstants.Policies.All, policy => policy.RequireClaim("id").RequireAuthenticatedUser().Build());
+
+            return services;
+        }
+
+        private IServiceCollection AddClerkBackendApi()
+        {
+            services.AddSingleton(sp =>
+            {
+                var authOptions = sp.GetRequiredService<IOptions<AuthOptions>>().Value;
+                return new ClerkBackendApi(bearerAuth: authOptions.SecretKey);
+            });
 
             return services;
         }

--- a/apps/api/src/Infrastructure/Infrastructure.csproj
+++ b/apps/api/src/Infrastructure/Infrastructure.csproj
@@ -5,12 +5,10 @@
     </PropertyGroup>
     <ItemGroup>
         <!-- Auth -->
+        <PackageReference Include="Clerk.BackendAPI"/>
         <PackageReference Include="AspNetCore.HealthChecks.NpgSql" />
         <PackageReference Include="AspNetCore.HealthChecks.UI.Client" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer"/>
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect"/>
-        <PackageReference Include="Microsoft.Identity.Web"/>
-        <PackageReference Include="Microsoft.Identity.Web.DownstreamApi"/>
         <!-- Database -->
         <PackageReference Include="EFCore.NamingConventions" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL"/>


### PR DESCRIPTION
### Pull Request

#### Checklist

- [ ] Code documented
- [ ] Version updated
- [ ] Tests created
- [x] Docs/Readme updated

#### New Features, Bugfixes and more

- Integrates the official `Clerk.BackendAPI` SDK and registers the backend client and request authentication options as singletons.
- Keeps ASP.NET Core `JwtBearer` authentication while sharing `AuthorizedParties` and clock-skew configuration with Clerk.
- Removes unused Microsoft Identity Web and OpenID Connect dependencies and documents the new `SecretKey` and `AuthorizedParties` configuration.

Validation: API build, format, and lint pass. The dependency audit reports the existing high-severity advisory for transitive package `Microsoft.OpenApi` 2.0.0 (`GHSA-v5pm-xwqc-g5wc`).

Refs: KIJK-285
