### PR TITLE
fix(api): skip current user lookup for unmatched routes

### DIFF
--- a/apps/api/src/Api/Middleware/CurrentUserMiddleware.cs
+++ b/apps/api/src/Api/Middleware/CurrentUserMiddleware.cs
@@ -17,6 +17,12 @@ public class CurrentUserMiddleware(IProblemDetailsService problemDetailsService,
 {
     public async Task InvokeAsync(HttpContext context, RequestDelegate next)
     {
+        if (context.GetEndpoint() is null)
+        {
+            await next(context);
+            return;
+        }
+
         var (isSuccess, errorMessage) = await SetCurrentUser(context);
         if (isSuccess)
         {


### PR DESCRIPTION
## Summary

- skip current-user resolution when endpoint routing did not match a backend endpoint
- let unmatched scanner and probe requests complete through the normal ASP.NET Core pipeline as `404 Not Found`
- prevent misleading authentication errors and Sentry events for paths such as `/.claude/.credentials.json`

## Root cause

`CurrentUserMiddleware` ran globally and attempted to resolve a user even when endpoint routing had not selected an endpoint. Requests to unknown paths therefore produced `User for id '' was not found` instead of a normal 404 response.

## Impact

Known API endpoints continue to resolve the current user as before. Unknown routes no longer perform a user lookup or emit an authentication problem.

## Validation

- `dotnet build apps/api/Kijk.slnx -c Release`
- `dotnet format apps/api/Kijk.slnx --verify-no-changes --exclude '**/Migrations/'`
- `git diff --check`

Linear: [KIJK-336](https://linear.app/justmax/issue/KIJK-336/current-user-lookup-fails-when-user-id-is-empty)