### PR TITLE
fix(api): return appropriate HTTP status codes

### DIFF
--- a/apps/api/src/Api/Endpoints/ConsumptionsEndpoints.cs
+++ b/apps/api/src/Api/Endpoints/ConsumptionsEndpoints.cs
@@ -24,6 +24,7 @@ public class ConsumptionsEndpoints : IEndpointGroup
             .WithTags("Consumptions");
 
         group.MapGet("/{id:guid}", GetById)
+            .WithName("GetConsumptionById")
             .WithSummary("Gets a consumption by id");
 
         group.MapGet("/", GetByYearMonth)
@@ -111,10 +112,13 @@ public class ConsumptionsEndpoints : IEndpointGroup
     /// <param name="handler"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    private static async Task<Results<Ok<ConsumptionResponse>, ProblemHttpResult>> Create(CreateConsumptionRequest request, CreateConsumptionHandler handler, CancellationToken cancellationToken)
+    private static async Task<Results<CreatedAtRoute<ConsumptionResponse>, ProblemHttpResult>> Create(CreateConsumptionRequest request,
+        CreateConsumptionHandler handler, CancellationToken cancellationToken)
     {
         var result = await handler.CreateAsync(request, cancellationToken);
-        return result.IsError ? TypedResults.Problem(result.Error.ToProblemDetails()) : TypedResults.Ok(result.Value);
+        return result.IsError
+            ? TypedResults.Problem(result.Error.ToProblemDetails())
+            : TypedResults.CreatedAtRoute(result.Value, "GetConsumptionById", new { id = result.Value.Id });
     }
 
     /// <summary>
@@ -139,9 +143,9 @@ public class ConsumptionsEndpoints : IEndpointGroup
     /// <param name="handler"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    private static async Task<Results<Ok<bool>, ProblemHttpResult>> Delete(Guid id, DeleteConsumptionHandler handler, CancellationToken cancellationToken)
+    private static async Task<Results<NoContent, ProblemHttpResult>> Delete(Guid id, DeleteConsumptionHandler handler, CancellationToken cancellationToken)
     {
         var result = await handler.DeleteAsync(id, cancellationToken);
-        return result.IsError ? TypedResults.Problem(result.Error.ToProblemDetails()) : TypedResults.Ok(result.Value);
+        return result.IsError ? TypedResults.Problem(result.Error.ToProblemDetails()) : TypedResults.NoContent();
     }
 }

--- a/apps/api/src/Api/Endpoints/ResourcesEndpoints.cs
+++ b/apps/api/src/Api/Endpoints/ResourcesEndpoints.cs
@@ -25,6 +25,7 @@ public class ResourcesEndpoints : IEndpointGroup
             .WithSummary("Gets all resources");
 
         group.MapGet("/{id:guid}", GetById)
+            .WithName("GetResourceById")
             .WithSummary("Gets an resource usage");
 
         group.MapPost("", Create)
@@ -72,10 +73,13 @@ public class ResourcesEndpoints : IEndpointGroup
     /// <param name="handler"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    private static async Task<Results<Ok<ResourceResponse>, ProblemHttpResult>> Create(CreateResourceRequest request, CreateResourceHandler handler, CancellationToken cancellationToken)
+    private static async Task<Results<CreatedAtRoute<ResourceResponse>, ProblemHttpResult>> Create(CreateResourceRequest request, CreateResourceHandler handler,
+        CancellationToken cancellationToken)
     {
         var result = await handler.CreateAsync(request, cancellationToken);
-        return result.IsError ? TypedResults.Problem(result.Error.ToProblemDetails()) : TypedResults.Ok(result.Value);
+        return result.IsError
+            ? TypedResults.Problem(result.Error.ToProblemDetails())
+            : TypedResults.CreatedAtRoute(result.Value, "GetResourceById", new { id = result.Value.Id });
     }
 
     /// <summary>
@@ -99,9 +103,9 @@ public class ResourcesEndpoints : IEndpointGroup
     /// <param name="handler"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    private static async Task<Results<Ok<bool>, ProblemHttpResult>> Delete(Guid id, DeleteResourceHandler handler, CancellationToken cancellationToken)
+    private static async Task<Results<NoContent, ProblemHttpResult>> Delete(Guid id, DeleteResourceHandler handler, CancellationToken cancellationToken)
     {
         var result = await handler.DeleteAsync(id, cancellationToken);
-        return result.IsError ? TypedResults.Problem(result.Error.ToProblemDetails()) : TypedResults.Ok(result.Value);
+        return result.IsError ? TypedResults.Problem(result.Error.ToProblemDetails()) : TypedResults.NoContent();
     }
 }

--- a/apps/api/src/Api/Extensions/ErrorExtensions.cs
+++ b/apps/api/src/Api/Extensions/ErrorExtensions.cs
@@ -37,6 +37,7 @@ public static class ErrorExtensions
         ErrorType.Authorization => "Authorization error",
         ErrorType.NotFound => "Resource not found",
         ErrorType.Conflict => "Conflict",
-        _ => "Unexpected Server error",
+        ErrorType.Validation => "Validation error",
+        _ => "Unexpected server error",
     };
 }

--- a/apps/api/src/Api/Extensions/OpenApi/ComponentResponseTransformer.cs
+++ b/apps/api/src/Api/Extensions/OpenApi/ComponentResponseTransformer.cs
@@ -19,6 +19,7 @@ public class ComponentResponseTransformer : IOpenApiDocumentTransformer
         document.Components.Responses.Add("401", CreateErrorResponse("Unauthenticated.", document));
         document.Components.Responses.Add("403", CreateErrorResponse("Unauthorized.", document));
         document.Components.Responses.Add("404", CreateErrorResponse("Not found.", document));
+        document.Components.Responses.Add("409", CreateErrorResponse("Conflict.", document));
         document.Components.Responses.Add("429", CreateErrorResponse("Too many requests.", document));
         document.Components.Responses.Add("500", CreateErrorResponse("Internal server error.", document));
     }
@@ -37,31 +38,29 @@ public class ComponentResponseTransformer : IOpenApiDocumentTransformer
     {
         var problemSchema = await context.GetOrCreateSchemaAsync(typeof(ProblemDetails), null, cancellationToken);
         problemSchema.AdditionalPropertiesAllowed = true;
-        problemSchema.Properties ??= new Dictionary<string, IOpenApiSchema>()
+        problemSchema.Properties ??= new Dictionary<string, IOpenApiSchema>();
+        problemSchema.Properties["errorType"] = new OpenApiSchema
         {
-            ["errorType"] = new OpenApiSchema
-            {
-                Enum =
-                [
-                    "Authentication",
-                    "Authorization",
-                    "NotFound",
-                    "Conflict",
-                    "Unexpected",
-                ],
-                Default = "<Type placeholder>"
-            },
-            ["timestamp"] = new OpenApiSchema
-            {
-                Type = JsonSchemaType.String,
-                Format = "date-time",
-                Description = "The date and time when the error occurred."
-            },
-            ["correlationId"] = new OpenApiSchema
-            {
-                Type = JsonSchemaType.String,
-                Description = "The correlation ID for the request."
-            }
+            Enum =
+            [
+                "Authentication",
+                "Authorization",
+                "NotFound",
+                "Conflict",
+                "Validation",
+                "Unexpected",
+            ]
+        };
+        problemSchema.Properties["timestamp"] = new OpenApiSchema
+        {
+            Type = JsonSchemaType.String,
+            Format = "date-time",
+            Description = "The date and time when the error occurred."
+        };
+        problemSchema.Properties["correlationId"] = new OpenApiSchema
+        {
+            Type = JsonSchemaType.String,
+            Description = "The correlation ID for the request."
         };
         return problemSchema;
     }

--- a/apps/api/src/Api/Extensions/OpenApi/OperationResponseTransformer.cs
+++ b/apps/api/src/Api/Extensions/OpenApi/OperationResponseTransformer.cs
@@ -12,6 +12,7 @@ public class OperationResponseTransformer : IOpenApiOperationTransformer
         operation.Responses["401"] = new OpenApiResponseReference("401");
         operation.Responses["403"] = new OpenApiResponseReference("403");
         operation.Responses["404"] = new OpenApiResponseReference("404");
+        operation.Responses["409"] = new OpenApiResponseReference("409");
         operation.Responses["429"] = new OpenApiResponseReference("429");
         operation.Responses["500"] = new OpenApiResponseReference("500");
 

--- a/apps/api/src/Api/kijk_openapi.json
+++ b/apps/api/src/Api/kijk_openapi.json
@@ -12,6 +12,7 @@
           "Consumptions"
         ],
         "summary": "Gets a consumption by id",
+        "operationId": "GetConsumptionById",
         "parameters": [
           {
             "name": "id",
@@ -45,6 +46,9 @@
           },
           "404": {
             "$ref": "#/components/responses/404"
+          },
+          "409": {
+            "$ref": "#/components/responses/409"
           },
           "429": {
             "$ref": "#/components/responses/429"
@@ -108,6 +112,9 @@
           "404": {
             "$ref": "#/components/responses/404"
           },
+          "409": {
+            "$ref": "#/components/responses/409"
+          },
           "429": {
             "$ref": "#/components/responses/429"
           },
@@ -138,15 +145,8 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "boolean"
-                }
-              }
-            }
+          "204": {
+            "description": "No Content"
           },
           "400": {
             "$ref": "#/components/responses/400"
@@ -159,6 +159,9 @@
           },
           "404": {
             "$ref": "#/components/responses/404"
+          },
+          "409": {
+            "$ref": "#/components/responses/409"
           },
           "429": {
             "$ref": "#/components/responses/429"
@@ -227,6 +230,9 @@
           "404": {
             "$ref": "#/components/responses/404"
           },
+          "409": {
+            "$ref": "#/components/responses/409"
+          },
           "429": {
             "$ref": "#/components/responses/429"
           },
@@ -256,8 +262,8 @@
           "required": true
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "201": {
+            "description": "Created",
             "content": {
               "application/json": {
                 "schema": {
@@ -277,6 +283,9 @@
           },
           "404": {
             "$ref": "#/components/responses/404"
+          },
+          "409": {
+            "$ref": "#/components/responses/409"
           },
           "429": {
             "$ref": "#/components/responses/429"
@@ -344,6 +353,9 @@
           "404": {
             "$ref": "#/components/responses/404"
           },
+          "409": {
+            "$ref": "#/components/responses/409"
+          },
           "429": {
             "$ref": "#/components/responses/429"
           },
@@ -386,6 +398,9 @@
           },
           "404": {
             "$ref": "#/components/responses/404"
+          },
+          "409": {
+            "$ref": "#/components/responses/409"
           },
           "429": {
             "$ref": "#/components/responses/429"
@@ -433,6 +448,9 @@
           "404": {
             "$ref": "#/components/responses/404"
           },
+          "409": {
+            "$ref": "#/components/responses/409"
+          },
           "429": {
             "$ref": "#/components/responses/429"
           },
@@ -462,8 +480,8 @@
           "required": true
         },
         "responses": {
-          "200": {
-            "description": "OK",
+          "201": {
+            "description": "Created",
             "content": {
               "application/json": {
                 "schema": {
@@ -483,6 +501,9 @@
           },
           "404": {
             "$ref": "#/components/responses/404"
+          },
+          "409": {
+            "$ref": "#/components/responses/409"
           },
           "429": {
             "$ref": "#/components/responses/429"
@@ -504,6 +525,7 @@
           "Resources"
         ],
         "summary": "Gets an resource usage",
+        "operationId": "GetResourceById",
         "parameters": [
           {
             "name": "id",
@@ -537,6 +559,9 @@
           },
           "404": {
             "$ref": "#/components/responses/404"
+          },
+          "409": {
+            "$ref": "#/components/responses/409"
           },
           "429": {
             "$ref": "#/components/responses/429"
@@ -600,6 +625,9 @@
           "404": {
             "$ref": "#/components/responses/404"
           },
+          "409": {
+            "$ref": "#/components/responses/409"
+          },
           "429": {
             "$ref": "#/components/responses/429"
           },
@@ -630,15 +658,8 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "boolean"
-                }
-              }
-            }
+          "204": {
+            "description": "No Content"
           },
           "400": {
             "$ref": "#/components/responses/400"
@@ -651,6 +672,9 @@
           },
           "404": {
             "$ref": "#/components/responses/404"
+          },
+          "409": {
+            "$ref": "#/components/responses/409"
           },
           "429": {
             "$ref": "#/components/responses/429"
@@ -695,6 +719,9 @@
           "404": {
             "$ref": "#/components/responses/404"
           },
+          "409": {
+            "$ref": "#/components/responses/409"
+          },
           "429": {
             "$ref": "#/components/responses/429"
           },
@@ -737,6 +764,9 @@
           },
           "404": {
             "$ref": "#/components/responses/404"
+          },
+          "409": {
+            "$ref": "#/components/responses/409"
           },
           "429": {
             "$ref": "#/components/responses/429"
@@ -791,6 +821,9 @@
           "404": {
             "$ref": "#/components/responses/404"
           },
+          "409": {
+            "$ref": "#/components/responses/409"
+          },
           "429": {
             "$ref": "#/components/responses/429"
           },
@@ -843,6 +876,9 @@
           },
           "404": {
             "$ref": "#/components/responses/404"
+          },
+          "409": {
+            "$ref": "#/components/responses/409"
           },
           "429": {
             "$ref": "#/components/responses/429"
@@ -1230,6 +1266,25 @@
               "null",
               "string"
             ]
+          },
+          "errorType": {
+            "enum": [
+              "Authentication",
+              "Authorization",
+              "NotFound",
+              "Conflict",
+              "Validation",
+              "Unexpected"
+            ]
+          },
+          "timestamp": {
+            "type": "string",
+            "description": "The date and time when the error occurred.",
+            "format": "date-time"
+          },
+          "correlationId": {
+            "type": "string",
+            "description": "The correlation ID for the request."
           }
         }
       },
@@ -1544,6 +1599,16 @@
       },
       "404": {
         "description": "Not found.",
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/Problem"
+            }
+          }
+        }
+      },
+      "409": {
+        "description": "Conflict.",
         "content": {
           "application/problem+json": {
             "schema": {

--- a/apps/api/src/Application/Consumptions/Create/CreateConsumption.cs
+++ b/apps/api/src/Application/Consumptions/Create/CreateConsumption.cs
@@ -37,7 +37,7 @@ public class CreateConsumptionHandler(IAppDbContext dbContext, CurrentUser curre
         if (foundConsumption is not null)
         {
             logger.LogWarning("Consumption for '{ResourceName}' already exists for {Date:MMMM yyyy}", request.Name, request.Date);
-            return Error.Validation($"Consumption for '{foundConsumption.Resource.Name}' already exists for {request.Date:MMMM yyyy}");
+            return Error.Conflict($"Consumption for '{foundConsumption.Resource.Name}' already exists for {request.Date:MMMM yyyy}");
         }
 
         var resource = await dbContext.Resources.FirstOrDefaultAsync(x => x.Id == request.ResourceId, cancellationToken);

--- a/apps/api/src/Application/Consumptions/GetByYearMonth/GetByYearMonth.cs
+++ b/apps/api/src/Application/Consumptions/GetByYearMonth/GetByYearMonth.cs
@@ -13,7 +13,16 @@ public class GetByYearMonthHandler(IAppDbContext dbContext, CurrentUser currentU
 {
     public async Task<Result<List<ConsumptionResponse>>> GetByYearMonthAsync(int? year, string? month, CancellationToken cancellationToken)
     {
-        var monthInt = month is not null ? DateTime.ParseExact(month, "MMMM", CultureInfo.InvariantCulture).Month : -1;
+        var monthInt = -1;
+        if (month is not null)
+        {
+            if (!DateTime.TryParseExact(month, "MMMM", CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsedMonth))
+            {
+                return Error.Validation($"Month '{month}' is invalid");
+            }
+
+            monthInt = parsedMonth.Month;
+        }
 
         var response = await dbContext.Consumptions
             .AsNoTracking()

--- a/apps/api/src/Application/Consumptions/GetStats/GetStatsConsumptions.cs
+++ b/apps/api/src/Application/Consumptions/GetStats/GetStatsConsumptions.cs
@@ -16,6 +16,11 @@ public class GetStatsConsumptionsHandler(IAppDbContext dbContext, CurrentUser cu
 {
     public async Task<Result<GetStatsConsumptionsResponseWrapper>> GetStatsAsync(int year, string month, CancellationToken cancellationToken)
     {
+        if (!DateTime.TryParseExact(month, "MMMM", CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsedMonth))
+        {
+            return Error.Validation($"Month '{month}' is invalid");
+        }
+
         var selectedYearUsages = await dbContext.Consumptions
             .Include(x => x.Resource)
             .Where(x => x.HouseholdId == currentUser.ActiveHouseholdId)
@@ -23,7 +28,7 @@ public class GetStatsConsumptionsHandler(IAppDbContext dbContext, CurrentUser cu
             .AsNoTracking()
             .ToListAsync(cancellationToken);
 
-        var selectedMonth = DateTime.ParseExact(month, "MMMM", CultureInfo.InvariantCulture).Month;
+        var selectedMonth = parsedMonth.Month;
         var comparisonYear = GetComparisonYear(year);
         var comparisonYearUsages = await dbContext.Consumptions
             .Where(x => x.HouseholdId == currentUser.ActiveHouseholdId)

--- a/apps/api/src/Application/Resources/Create/CreateResource.cs
+++ b/apps/api/src/Application/Resources/Create/CreateResource.cs
@@ -27,7 +27,7 @@ public class CreateResourceHandler(IAppDbContext dbContext, CurrentUser currentU
         if (user.Resources.Any(c => string.Equals(c.Name, command.Name, StringComparison.OrdinalIgnoreCase)))
         {
             logger.LogWarning("Resource with name '{Name}' already exists", command.Name);
-            return Error.Validation($"A resource with the name '{command.Name}' already exists");
+            return Error.Conflict($"A resource with the name '{command.Name}' already exists");
         }
 
         var newResource = new Resource

--- a/apps/api/src/Application/Resources/Delete/DeleteResource.cs
+++ b/apps/api/src/Application/Resources/Delete/DeleteResource.cs
@@ -25,7 +25,7 @@ public class DeleteResourceHandler(IAppDbContext dbContext, CurrentUser currentU
         if (user.Resources.ToList().Find(x => x.Id == id) is null)
         {
             logger.LogWarning("User with id '{UserId}' was not allowed to delete the resource type with id '{CategoryId}'", currentUser.Id, id);
-            return Error.Validation("You are not allowed to delete the resource type");
+            return Error.Authorization("You are not allowed to delete the resource type");
         }
 
         var foundResource = await dbContext.Resources.FindAsync([id], cancellationToken);
@@ -38,7 +38,7 @@ public class DeleteResourceHandler(IAppDbContext dbContext, CurrentUser currentU
         if (foundResource.CreatorType == CreatorType.System)
         {
             logger.LogWarning("Resource with id '{Id}' could not be deleted, because it is of creator type 'Default'", id);
-            return Error.Validation("Resource could not be deleted, because it is a default type");
+            return Error.Authorization("Resource could not be deleted, because it is a default type");
         }
 
         user.DeleteResource(foundResource.Id);

--- a/apps/api/src/Application/Users/Welcome/WelcomeUser.cs
+++ b/apps/api/src/Application/Users/Welcome/WelcomeUser.cs
@@ -28,13 +28,13 @@ public class WelcomeUserHandler(IAppDbContext dbContext, CurrentUser currentUser
         if (request.UserName is null)
         {
             logger.LogError("User name is null");
-            return Error.Unexpected("User name is null");
+            return Error.Validation("User name is required");
         }
 
         if (!user.FirstTime)
         {
             logger.LogError("User is already welcome");
-            return Error.Unexpected("Your are already welcome");
+            return Error.Conflict("User has already completed the welcome flow");
         }
 
         user.FirstTime = false;

--- a/apps/api/src/Shared/Error.cs
+++ b/apps/api/src/Shared/Error.cs
@@ -70,6 +70,20 @@ public readonly record struct Error
         new(ErrorCodes.NotFoundError, description, ErrorType.NotFound);
 
     /// <summary>
+    /// Creates an <see cref="Error" /> of type <see cref="ErrorType.Conflict" /> from a description.
+    /// </summary>
+    /// <param name="description">The error description.</param>
+    public static Error Conflict(string description = "A conflict has occurred.") =>
+        new(ErrorCodes.ConflictError, description, ErrorType.Conflict);
+
+    /// <summary>
+    /// Creates an <see cref="Error" /> of type <see cref="ErrorType.Authorization" /> from a description.
+    /// </summary>
+    /// <param name="description">The error description.</param>
+    public static Error Authorization(string description = "You are not authorized to perform this action.") =>
+        new(ErrorCodes.AuthorizationError, description, ErrorType.Authorization);
+
+    /// <summary>
     /// Creates an <see cref="Error" /> with the given numeric <paramref name="type" />,
     /// <paramref name="code" />, and <paramref name="description" />.
     /// </summary>

--- a/apps/api/src/Shared/ErrorCodes.cs
+++ b/apps/api/src/Shared/ErrorCodes.cs
@@ -23,4 +23,5 @@ public readonly record struct ErrorCodes
 
     public const string AuthenticationError = "E0005";
     public const string AuthorizationError = "E0006";
+    public const string ConflictError = "E0007";
 }

--- a/apps/client/src/shared/api/consumptions/requests.ts
+++ b/apps/client/src/shared/api/consumptions/requests.ts
@@ -1,10 +1,10 @@
 import { apiClient } from '@/shared/lib/api-client';
-import { unwrapApiData } from '@/shared/utils/http';
+import { ensureApiSuccess, unwrapApiResponse } from '@/shared/utils/http';
 
 import type { ConsumptionData } from './types';
 
 export async function getYears(signal?: AbortSignal) {
-  return unwrapApiData(await apiClient.GET('/api/consumptions/years', { signal }));
+  return unwrapApiResponse(await apiClient.GET('/api/consumptions/years', { signal }));
 }
 
 /**
@@ -20,7 +20,7 @@ export async function getYears(signal?: AbortSignal) {
  * @returns The list of resources
  */
 export async function getConsumptionsBy(year?: string, month?: string, signal?: AbortSignal) {
-  return unwrapApiData(
+  return unwrapApiResponse(
     await apiClient.GET('/api/consumptions', {
       params: { query: { month, year } },
       signal,
@@ -41,7 +41,7 @@ export async function getConsumptionsStats(year?: string, month?: string, signal
     throw new Error('Year and month are required to load consumption stats.');
   }
 
-  return unwrapApiData(
+  return unwrapApiResponse(
     await apiClient.GET('/api/consumptions/stats', {
       params: { query: { month, year } },
       signal,
@@ -50,7 +50,7 @@ export async function getConsumptionsStats(year?: string, month?: string, signal
 }
 
 export async function createConsumption(data: ConsumptionData, signal?: AbortSignal) {
-  return unwrapApiData(
+  return unwrapApiResponse(
     await apiClient.POST('/api/consumptions', {
       body: {
         date: data.date.toISOString(),
@@ -65,7 +65,7 @@ export async function createConsumption(data: ConsumptionData, signal?: AbortSig
 }
 
 export async function updateConsumption(id: string, data: Partial<ConsumptionData>, signal?: AbortSignal) {
-  return unwrapApiData(
+  return unwrapApiResponse(
     await apiClient.PUT('/api/consumptions/{id}', {
       body: {
         date: data.date?.toISOString() ?? null,
@@ -83,7 +83,7 @@ export async function updateConsumption(id: string, data: Partial<ConsumptionDat
 }
 
 export async function deleteConsumption(id: string, signal?: AbortSignal) {
-  return unwrapApiData(
+  return ensureApiSuccess(
     await apiClient.DELETE('/api/consumptions/{id}', {
       params: {
         path: { id },

--- a/apps/client/src/shared/api/generated/kijk.ts
+++ b/apps/client/src/shared/api/generated/kijk.ts
@@ -9,34 +9,7 @@ export interface paths {
       cookie?: never;
     };
     /** Gets a consumption by id */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** OK */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ConsumptionResponse'];
-          };
-        };
-        400: components['responses']['400'];
-        401: components['responses']['401'];
-        403: components['responses']['403'];
-        404: components['responses']['404'];
-        429: components['responses']['429'];
-        500: components['responses']['500'];
-      };
-    };
+    get: operations['GetConsumptionById'];
     /** Updates a consumption */
     put: {
       parameters: {
@@ -66,6 +39,7 @@ export interface paths {
         401: components['responses']['401'];
         403: components['responses']['403'];
         404: components['responses']['404'];
+        409: components['responses']['409'];
         429: components['responses']['429'];
         500: components['responses']['500'];
       };
@@ -83,19 +57,18 @@ export interface paths {
       };
       requestBody?: never;
       responses: {
-        /** OK */
-        200: {
+        /** No Content */
+        204: {
           headers: {
             [name: string]: unknown;
           };
-          content: {
-            'application/json': boolean;
-          };
+          content?: never;
         };
         400: components['responses']['400'];
         401: components['responses']['401'];
         403: components['responses']['403'];
         404: components['responses']['404'];
+        409: components['responses']['409'];
         429: components['responses']['429'];
         500: components['responses']['500'];
       };
@@ -138,6 +111,7 @@ export interface paths {
         401: components['responses']['401'];
         403: components['responses']['403'];
         404: components['responses']['404'];
+        409: components['responses']['409'];
         429: components['responses']['429'];
         500: components['responses']['500'];
       };
@@ -157,8 +131,8 @@ export interface paths {
         };
       };
       responses: {
-        /** OK */
-        200: {
+        /** Created */
+        201: {
           headers: {
             [name: string]: unknown;
           };
@@ -170,6 +144,7 @@ export interface paths {
         401: components['responses']['401'];
         403: components['responses']['403'];
         404: components['responses']['404'];
+        409: components['responses']['409'];
         429: components['responses']['429'];
         500: components['responses']['500'];
       };
@@ -213,6 +188,7 @@ export interface paths {
         401: components['responses']['401'];
         403: components['responses']['403'];
         404: components['responses']['404'];
+        409: components['responses']['409'];
         429: components['responses']['429'];
         500: components['responses']['500'];
       };
@@ -255,6 +231,7 @@ export interface paths {
         401: components['responses']['401'];
         403: components['responses']['403'];
         404: components['responses']['404'];
+        409: components['responses']['409'];
         429: components['responses']['429'];
         500: components['responses']['500'];
       };
@@ -297,6 +274,7 @@ export interface paths {
         401: components['responses']['401'];
         403: components['responses']['403'];
         404: components['responses']['404'];
+        409: components['responses']['409'];
         429: components['responses']['429'];
         500: components['responses']['500'];
       };
@@ -316,8 +294,8 @@ export interface paths {
         };
       };
       responses: {
-        /** OK */
-        200: {
+        /** Created */
+        201: {
           headers: {
             [name: string]: unknown;
           };
@@ -329,6 +307,7 @@ export interface paths {
         401: components['responses']['401'];
         403: components['responses']['403'];
         404: components['responses']['404'];
+        409: components['responses']['409'];
         429: components['responses']['429'];
         500: components['responses']['500'];
       };
@@ -347,34 +326,7 @@ export interface paths {
       cookie?: never;
     };
     /** Gets an resource usage */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** OK */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ResourceResponse'];
-          };
-        };
-        400: components['responses']['400'];
-        401: components['responses']['401'];
-        403: components['responses']['403'];
-        404: components['responses']['404'];
-        429: components['responses']['429'];
-        500: components['responses']['500'];
-      };
-    };
+    get: operations['GetResourceById'];
     /** Updates an resource usage */
     put: {
       parameters: {
@@ -404,6 +356,7 @@ export interface paths {
         401: components['responses']['401'];
         403: components['responses']['403'];
         404: components['responses']['404'];
+        409: components['responses']['409'];
         429: components['responses']['429'];
         500: components['responses']['500'];
       };
@@ -421,19 +374,18 @@ export interface paths {
       };
       requestBody?: never;
       responses: {
-        /** OK */
-        200: {
+        /** No Content */
+        204: {
           headers: {
             [name: string]: unknown;
           };
-          content: {
-            'application/json': boolean;
-          };
+          content?: never;
         };
         400: components['responses']['400'];
         401: components['responses']['401'];
         403: components['responses']['403'];
         404: components['responses']['404'];
+        409: components['responses']['409'];
         429: components['responses']['429'];
         500: components['responses']['500'];
       };
@@ -473,6 +425,7 @@ export interface paths {
         401: components['responses']['401'];
         403: components['responses']['403'];
         404: components['responses']['404'];
+        409: components['responses']['409'];
         429: components['responses']['429'];
         500: components['responses']['500'];
       };
@@ -515,6 +468,7 @@ export interface paths {
         401: components['responses']['401'];
         403: components['responses']['403'];
         404: components['responses']['404'];
+        409: components['responses']['409'];
         429: components['responses']['429'];
         500: components['responses']['500'];
       };
@@ -562,6 +516,7 @@ export interface paths {
         401: components['responses']['401'];
         403: components['responses']['403'];
         404: components['responses']['404'];
+        409: components['responses']['409'];
         429: components['responses']['429'];
         500: components['responses']['500'];
       };
@@ -608,6 +563,7 @@ export interface paths {
         401: components['responses']['401'];
         403: components['responses']['403'];
         404: components['responses']['404'];
+        409: components['responses']['409'];
         429: components['responses']['429'];
         500: components['responses']['500'];
       };
@@ -709,6 +665,16 @@ export interface components {
       status?: null | number | string;
       detail?: null | string;
       instance?: null | string;
+      /** @enum {unknown} */
+      errorType?: 'Authentication' | 'Authorization' | 'NotFound' | 'Conflict' | 'Validation' | 'Unexpected';
+      /**
+       * Format: date-time
+       *
+       * The date and time when the error occurred.
+       */
+      timestamp?: string;
+      /** The correlation ID for the request. */
+      correlationId?: string;
     };
     ResourceResponse: {
       /** Format: uuid */
@@ -722,12 +688,14 @@ export interface components {
       name: null | string;
       /** Format: double */
       value: null | number | string;
-      valueType: components['schemas']['CreateConsumptionValueTypes'];
+      valueType: components['schemas']['UpdateConsumptionValueTypes'];
       /** Format: uuid */
       resourceId: null | string;
       /** Format: date-time */
       date: null | string;
     };
+    /** @enum {unknown} */
+    UpdateConsumptionValueTypes: 'Absolute' | 'Relative';
     UpdateResourceRequest: {
       name: null | string;
       color: null | string;
@@ -810,6 +778,15 @@ export interface components {
         'application/problem+json': components['schemas']['Problem'];
       };
     };
+    /** Conflict. */
+    409: {
+      headers: {
+        [name: string]: unknown;
+      };
+      content: {
+        'application/problem+json': components['schemas']['Problem'];
+      };
+    };
     /** Too many requests. */
     429: {
       headers: {
@@ -835,4 +812,63 @@ export interface components {
   pathItems: never;
 }
 export type $defs = Record<string, never>;
-export type operations = Record<string, never>;
+export interface operations {
+  GetConsumptionById: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ConsumptionResponse'];
+        };
+      };
+      400: components['responses']['400'];
+      401: components['responses']['401'];
+      403: components['responses']['403'];
+      404: components['responses']['404'];
+      409: components['responses']['409'];
+      429: components['responses']['429'];
+      500: components['responses']['500'];
+    };
+  };
+  GetResourceById: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ResourceResponse'];
+        };
+      };
+      400: components['responses']['400'];
+      401: components['responses']['401'];
+      403: components['responses']['403'];
+      404: components['responses']['404'];
+      409: components['responses']['409'];
+      429: components['responses']['429'];
+      500: components['responses']['500'];
+    };
+  };
+}

--- a/apps/client/src/shared/api/resources/requests.ts
+++ b/apps/client/src/shared/api/resources/requests.ts
@@ -1,14 +1,14 @@
 import { apiClient } from '@/shared/lib/api-client';
-import { unwrapApiData } from '@/shared/utils/http';
+import { ensureApiSuccess, unwrapApiResponse } from '@/shared/utils/http';
 
 import type { ResourceData, UpdateResourceData } from './types';
 
 export async function getResources(signal?: AbortSignal) {
-  return unwrapApiData(await apiClient.GET('/api/resources', { signal }));
+  return unwrapApiResponse(await apiClient.GET('/api/resources', { signal }));
 }
 
 export async function createResource(data: ResourceData, signal?: AbortSignal) {
-  return unwrapApiData(
+  return unwrapApiResponse(
     await apiClient.POST('/api/resources', {
       body: data,
       signal,
@@ -17,7 +17,7 @@ export async function createResource(data: ResourceData, signal?: AbortSignal) {
 }
 
 export async function updateResource(data: UpdateResourceData, signal?: AbortSignal) {
-  return unwrapApiData(
+  return unwrapApiResponse(
     await apiClient.PUT('/api/resources/{id}', {
       body: data.resourceType,
       params: {
@@ -29,7 +29,7 @@ export async function updateResource(data: UpdateResourceData, signal?: AbortSig
 }
 
 export async function deleteResource(id: string, signal?: AbortSignal) {
-  return unwrapApiData(
+  return ensureApiSuccess(
     await apiClient.DELETE('/api/resources/{id}', {
       params: {
         path: { id },

--- a/apps/client/src/shared/api/users/requests.ts
+++ b/apps/client/src/shared/api/users/requests.ts
@@ -1,14 +1,14 @@
 import { apiClient } from '@/shared/lib/api-client';
-import { unwrapApiData } from '@/shared/utils/http';
+import { unwrapApiResponse } from '@/shared/utils/http';
 
 import type { UpdateUserData, WelcomeUserData } from './types';
 
 export async function signInUser(signal?: AbortSignal) {
-  return unwrapApiData(await apiClient.GET('/api/users/sign-in', { signal }));
+  return unwrapApiResponse(await apiClient.GET('/api/users/sign-in', { signal }));
 }
 
 export async function updateUser(data: UpdateUserData) {
-  return unwrapApiData(
+  return unwrapApiResponse(
     await apiClient.PUT('/api/users', {
       body: { useDefaultResources: data.useDefaultResources ?? null, userName: data.userName ?? null },
     }),
@@ -16,7 +16,7 @@ export async function updateUser(data: UpdateUserData) {
 }
 
 export async function welcomeUser(data: WelcomeUserData) {
-  return unwrapApiData(
+  return unwrapApiResponse(
     await apiClient.PUT('/api/users/welcome', {
       body: { useDefaultResources: data.useDefaultResources ?? null, userName: data.userName ?? null },
     }),

--- a/apps/client/src/shared/utils/http.ts
+++ b/apps/client/src/shared/utils/http.ts
@@ -12,6 +12,17 @@ type ApiResponse<TData, TError> =
       response: Response;
     };
 
+type ApiResult<TError> = {
+  error?: TError;
+  response: Response;
+};
+
+function throwIfApiError<TError>(result: ApiResult<TError>) {
+  if (result.error) {
+    throw new ApiError(result.error, result.response);
+  }
+}
+
 /**
  * Unwraps the data from an API response, throwing an ApiError if the response contains an error or if the data is
  * undefined.
@@ -20,14 +31,17 @@ type ApiResponse<TData, TError> =
  * @returns The data from the API response if the call was successful.
  * @throws ApiError if the API call resulted in an error or if the response data is undefined.
  */
-export function unwrapApiData<TData, TError>(result: ApiResponse<TData, TError>) {
-  if (result.error) {
-    throw new ApiError(result.error, result.response);
-  }
+export function unwrapApiResponse<TData, TError>(result: ApiResponse<TData, TError>) {
+  throwIfApiError(result);
 
   if (result.data === undefined) {
     throw new ApiError({ status: result.response.status, title: 'Empty API response' }, result.response);
   }
 
   return result.data;
+}
+
+/** Ensures an API response succeeded without requiring a response body. */
+export function ensureApiSuccess<TError>(result: ApiResult<TError>) {
+  throwIfApiError(result);
 }


### PR DESCRIPTION
## Summary

- return `201 Created` with location headers from resource and consumption creation endpoints
- return `204 No Content` from successful delete endpoints
- map validation, authorization, not-found, and conflict failures to appropriate HTTP status codes
- document `409 Conflict` and custom Problem Details fields in OpenAPI
- regenerate the TypeScript API contract and handle bodyless success responses explicitly

## Why

All successful endpoints previously returned `200 OK`, including create and delete operations. Several expected domain failures were also surfaced as validation errors or unexpected `500` responses, making the API contract less predictable.

## Breaking changes

- creation endpoints now return `201` instead of `200`
- delete endpoints now return `204` without a boolean response body

## Validation

- `pnpm run build`
- `pnpm run fmt`
- `pnpm run lint`
- `pnpm run --filter kijk-client typecheck`
- React Doctor: 100/100
- Fallow: no introduced dead-code or complexity findings

No test scaffolding was added because it is covered by a separate ticket.

The dependency audit continues to report pre-existing repository vulnerabilities unrelated to this change.

Linear: [KIJK-291](https://linear.app/justmax/issue/KIJK-291/return-correct-http-status-codes)