### PR TITLE
refactor(api): replace manual mappings with Mapperly

### DIFF
--- a/apps/api/Directory.Packages.props
+++ b/apps/api/Directory.Packages.props
@@ -48,5 +48,6 @@
     <PackageVersion Include="Humanizer.Core.de" Version="3.0.10" />
     <PackageVersion Include="NetEscapades.AspNetCore.SecurityHeaders" Version="1.3.1" />
     <PackageVersion Include="NetEscapades.EnumGenerators" Version="1.0.0-beta21" />
+    <PackageVersion Include="Riok.Mapperly" Version="4.3.1" />
   </ItemGroup>
 </Project>

--- a/apps/api/src/Api/Api.csproj
+++ b/apps/api/src/Api/Api.csproj
@@ -43,6 +43,7 @@
         <PackageReference Include="Humanizer.Core.de"/>
         <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders"/>
         <PackageReference Include="NetEscapades.EnumGenerators"/>
+        <PackageReference Include="Riok.Mapperly" ExcludeAssets="runtime" PrivateAssets="all" />
     </ItemGroup>
 
     <ItemGroup>

--- a/apps/api/src/Api/Middleware/CurrentUserMiddleware.cs
+++ b/apps/api/src/Api/Middleware/CurrentUserMiddleware.cs
@@ -83,6 +83,6 @@ public class CurrentUserMiddleware(IProblemDetailsService problemDetailsService,
     private Task<SimpleAuthUser?> GetUserFromDb(string sub) => dbContext.Users
         .Where(x => x.AuthId == sub)
         .AsNoTracking()
-        .ProjectToSimpleAuthUser()
+        .ToSimpleAuthUser()
         .FirstOrDefaultAsync();
 }

--- a/apps/api/src/Api/Middleware/CurrentUserMiddleware.cs
+++ b/apps/api/src/Api/Middleware/CurrentUserMiddleware.cs
@@ -82,13 +82,7 @@ public class CurrentUserMiddleware(IProblemDetailsService problemDetailsService,
 
     private Task<SimpleAuthUser?> GetUserFromDb(string sub) => dbContext.Users
         .Where(x => x.AuthId == sub)
-        .Select(x => new SimpleAuthUser(
-            x.Id,
-            x.AuthId,
-            x.UserHouseholds.Where(userHousehold => userHousehold.IsActive).Select(userHousehold => userHousehold.HouseholdId).SingleOrDefault(),
-            x.Name,
-            x.Email,
-            x.FirstTime))
         .AsNoTracking()
+        .ProjectToSimpleAuthUser()
         .FirstOrDefaultAsync();
 }

--- a/apps/api/src/Api/Middleware/SimpleAuthUserMapper.cs
+++ b/apps/api/src/Api/Middleware/SimpleAuthUserMapper.cs
@@ -15,7 +15,7 @@ public static partial class SimpleAuthUserMapper
     /// </summary>
     /// <param name="source">The user query.</param>
     /// <returns>The projected authenticated-user query.</returns>
-    public static partial IQueryable<SimpleAuthUser> ProjectToSimpleAuthUser(this IQueryable<User> source);
+    public static partial IQueryable<SimpleAuthUser> ToSimpleAuthUser(this IQueryable<User> source);
 
     [MapPropertyFromSource(nameof(SimpleAuthUser.HouseholdId), Use = nameof(MapActiveHouseholdId))]
     private static partial SimpleAuthUser Map(User source);

--- a/apps/api/src/Api/Middleware/SimpleAuthUserMapper.cs
+++ b/apps/api/src/Api/Middleware/SimpleAuthUserMapper.cs
@@ -1,0 +1,27 @@
+using Kijk.Domain.Entities;
+using Kijk.Shared;
+using Riok.Mapperly.Abstractions;
+
+namespace Kijk.Api.Middleware;
+
+/// <summary>
+/// Projects user entities to the authenticated-user representation.
+/// </summary>
+[Mapper(RequiredMappingStrategy = RequiredMappingStrategy.Target)]
+public static partial class SimpleAuthUserMapper
+{
+    /// <summary>
+    /// Projects user entities to authenticated users in the underlying query provider.
+    /// </summary>
+    /// <param name="source">The user query.</param>
+    /// <returns>The projected authenticated-user query.</returns>
+    public static partial IQueryable<SimpleAuthUser> ProjectToSimpleAuthUser(this IQueryable<User> source);
+
+    [MapPropertyFromSource(nameof(SimpleAuthUser.HouseholdId), Use = nameof(MapActiveHouseholdId))]
+    private static partial SimpleAuthUser Map(User source);
+
+    private static Guid? MapActiveHouseholdId(User source) => source.UserHouseholds
+        .Where(userHousehold => userHousehold.IsActive)
+        .Select(userHousehold => userHousehold.HouseholdId)
+        .SingleOrDefault();
+}

--- a/apps/api/src/Application/Application.csproj
+++ b/apps/api/src/Application/Application.csproj
@@ -12,6 +12,7 @@
       <PackageReference Include="FluentValidation" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+      <PackageReference Include="Riok.Mapperly" ExcludeAssets="runtime" PrivateAssets="all" />
     </ItemGroup>
 
 </Project>

--- a/apps/api/src/Application/Consumptions/Create/CreateConsumption.cs
+++ b/apps/api/src/Application/Consumptions/Create/CreateConsumption.cs
@@ -52,13 +52,7 @@ public class CreateConsumptionHandler(IAppDbContext dbContext, CurrentUser curre
         dbContext.Consumptions.Add(consumption);
         await dbContext.SaveChangesAsync(cancellationToken);
 
-        return new ConsumptionResponse(
-            consumption.Id,
-            consumption.Name,
-            consumption.Description,
-            consumption.Value,
-            new(consumption.Resource.Id, consumption.Resource.Name, consumption.Resource.Unit, consumption.Resource.Color),
-            consumption.Date.ToDateTime());
+        return consumption.ToResponse();
     }
 
     // TODO valuetype should also be saved

--- a/apps/api/src/Application/Consumptions/GetById/GetByIdConsumption.cs
+++ b/apps/api/src/Application/Consumptions/GetById/GetByIdConsumption.cs
@@ -14,15 +14,8 @@ public class GetByIdConsumptionHandler(IAppDbContext dbContext, CurrentUser curr
     {
         var entity = await dbContext.Consumptions
             .AsNoTracking()
-            .Include(x => x.Resource)
             .Where(x => x.Id == id && x.HouseholdId == currentUser.ActiveHouseholdId)
-            .Select(x => new ConsumptionResponse(
-                x.Id,
-                x.Name,
-                x.Description,
-                x.Value,
-                new(x.Resource.Id, x.Resource.Name, x.Resource.Unit, x.Resource.Color),
-                x.Date.ToDateTime()))
+            .ProjectToResponse()
             .FirstOrDefaultAsync(cancellationToken);
 
         if (entity is null)

--- a/apps/api/src/Application/Consumptions/GetById/GetByIdConsumption.cs
+++ b/apps/api/src/Application/Consumptions/GetById/GetByIdConsumption.cs
@@ -15,7 +15,7 @@ public class GetByIdConsumptionHandler(IAppDbContext dbContext, CurrentUser curr
         var entity = await dbContext.Consumptions
             .AsNoTracking()
             .Where(x => x.Id == id && x.HouseholdId == currentUser.ActiveHouseholdId)
-            .ProjectToResponse()
+            .ToResponse()
             .FirstOrDefaultAsync(cancellationToken);
 
         if (entity is null)

--- a/apps/api/src/Application/Consumptions/GetByYearMonth/GetByYearMonth.cs
+++ b/apps/api/src/Application/Consumptions/GetByYearMonth/GetByYearMonth.cs
@@ -29,7 +29,7 @@ public class GetByYearMonthHandler(IAppDbContext dbContext, CurrentUser currentU
             .Where(x => x.HouseholdId == currentUser.ActiveHouseholdId)
             .If(year != null, q => q.Where(x => x.Date.Value.Year == year))
             .If(monthInt != -1, q => q.Where(x => x.Date.Value.Month == monthInt))
-            .ProjectToResponse()
+            .ToResponse()
             .ToListAsync(cancellationToken);
 
         return response;

--- a/apps/api/src/Application/Consumptions/GetByYearMonth/GetByYearMonth.cs
+++ b/apps/api/src/Application/Consumptions/GetByYearMonth/GetByYearMonth.cs
@@ -26,17 +26,10 @@ public class GetByYearMonthHandler(IAppDbContext dbContext, CurrentUser currentU
 
         var response = await dbContext.Consumptions
             .AsNoTracking()
-            .Include(x => x.Resource)
             .Where(x => x.HouseholdId == currentUser.ActiveHouseholdId)
             .If(year != null, q => q.Where(x => x.Date.Value.Year == year))
             .If(monthInt != -1, q => q.Where(x => x.Date.Value.Month == monthInt))
-            .Select(x => new ConsumptionResponse(
-                x.Id,
-                x.Name,
-                x.Description,
-                x.Value,
-                new(x.Resource.Id, x.Resource.Name, x.Resource.Unit, x.Resource.Color),
-                x.Date.ToDateTime()))
+            .ProjectToResponse()
             .ToListAsync(cancellationToken);
 
         return response;

--- a/apps/api/src/Application/Consumptions/Shared/ResponseMapper.cs
+++ b/apps/api/src/Application/Consumptions/Shared/ResponseMapper.cs
@@ -1,0 +1,28 @@
+using Kijk.Domain.Entities;
+using Kijk.Domain.ValueObjects;
+using Riok.Mapperly.Abstractions;
+
+namespace Kijk.Application.Consumptions.Shared;
+
+/// <summary>
+/// Maps consumption entities to API responses.
+/// </summary>
+[Mapper(RequiredMappingStrategy = RequiredMappingStrategy.Target)]
+public static partial class ConsumptionResponseMapper
+{
+    /// <summary>
+    /// Maps a materialized consumption entity to a response.
+    /// </summary>
+    /// <param name="source">The consumption to map.</param>
+    /// <returns>The mapped response.</returns>
+    public static partial ConsumptionResponse ToResponse(this Consumption source);
+
+    /// <summary>
+    /// Projects consumption entities to responses in the underlying query provider.
+    /// </summary>
+    /// <param name="source">The consumption query.</param>
+    /// <returns>The projected response query.</returns>
+    public static partial IQueryable<ConsumptionResponse> ProjectToResponse(this IQueryable<Consumption> source);
+
+    private static DateTime MapDate(MonthYear source) => source.Value;
+}

--- a/apps/api/src/Application/Consumptions/Shared/ResponseMapper.cs
+++ b/apps/api/src/Application/Consumptions/Shared/ResponseMapper.cs
@@ -22,7 +22,7 @@ public static partial class ConsumptionResponseMapper
     /// </summary>
     /// <param name="source">The consumption query.</param>
     /// <returns>The projected response query.</returns>
-    public static partial IQueryable<ConsumptionResponse> ProjectToResponse(this IQueryable<Consumption> source);
+    public static partial IQueryable<ConsumptionResponse> ToResponse(this IQueryable<Consumption> source);
 
     private static DateTime MapDate(MonthYear source) => source.Value;
 }

--- a/apps/api/src/Application/Consumptions/Update/UpdateConsumption.cs
+++ b/apps/api/src/Application/Consumptions/Update/UpdateConsumption.cs
@@ -60,14 +60,6 @@ public class UpdateConsumptionHandler(IAppDbContext dbContext, CurrentUser curre
 
         await dbContext.SaveChangesAsync(cancellationToken);
 
-        return new ConsumptionResponse(
-            existingResourceUsage.Id,
-            existingResourceUsage.Name,
-            existingResourceUsage.Description,
-            existingResourceUsage.Value,
-            new(existingResourceUsage.Resource.Id, existingResourceUsage.Resource.Name, existingResourceUsage.Resource.Unit,
-                existingResourceUsage.Resource.Color),
-            existingResourceUsage.Date.ToDateTime()
-        );
+        return existingResourceUsage.ToResponse();
     }
 }

--- a/apps/api/src/Application/Resources/Create/CreateResource.cs
+++ b/apps/api/src/Application/Resources/Create/CreateResource.cs
@@ -44,7 +44,6 @@ public class CreateResourceHandler(IAppDbContext dbContext, CurrentUser currentU
 
         await dbContext.SaveChangesAsync(cancellationToken);
 
-        return new ResourceResponse(resEntity.Entity.Id, resEntity.Entity.Name, resEntity.Entity.Color, resEntity.Entity.Unit,
-            resEntity.Entity.CreatorType);
+        return resEntity.Entity.ToResponse();
     }
 }

--- a/apps/api/src/Application/Resources/GetAll/GetAllResources.cs
+++ b/apps/api/src/Application/Resources/GetAll/GetAllResources.cs
@@ -12,20 +12,18 @@ public class GetAllResourcesHandler(IAppDbContext dbContext, CurrentUser current
 {
     public async Task<Result<List<ResourceResponse>>> GetAllAsync(CancellationToken cancellationToken)
     {
-        var user = await dbContext.Users
-            .Include(x => x.Resources)
+        var resources = await dbContext.Users
             .Where(x => x.Id == currentUser.Id)
-            .FirstOrDefaultAsync(cancellationToken);
+            .SelectMany(x => x.Resources)
+            .AsNoTracking()
+            .ProjectToResponse()
+            .ToListAsync(cancellationToken);
 
-        if (user is null)
+        if (resources.Count == 0 && !await dbContext.Users.AnyAsync(x => x.Id == currentUser.Id, cancellationToken))
         {
             logger.LogWarning("User with id '{UserId}' was not found", currentUser.Id);
             return Error.NotFound("User was not found");
         }
-
-        var resources = user.Resources
-            .Select(x => new ResourceResponse(x.Id, x.Name, x.Color, x.Unit, x.CreatorType))
-            .ToList();
 
         return resources;
     }

--- a/apps/api/src/Application/Resources/GetAll/GetAllResources.cs
+++ b/apps/api/src/Application/Resources/GetAll/GetAllResources.cs
@@ -16,7 +16,7 @@ public class GetAllResourcesHandler(IAppDbContext dbContext, CurrentUser current
             .Where(x => x.Id == currentUser.Id)
             .SelectMany(x => x.Resources)
             .AsNoTracking()
-            .ProjectToResponse()
+            .ToResponse()
             .ToListAsync(cancellationToken);
 
         if (resources.Count == 0 && !await dbContext.Users.AnyAsync(x => x.Id == currentUser.Id, cancellationToken))

--- a/apps/api/src/Application/Resources/GetById/GetByIdResource.cs
+++ b/apps/api/src/Application/Resources/GetById/GetByIdResource.cs
@@ -26,7 +26,7 @@ public class GetByIdResourceHandler(IAppDbContext dbContext, CurrentUser current
             .SelectMany(x => x.Resources)
             .Where(x => x.Id == id)
             .AsNoTracking()
-            .ProjectToResponse()
+            .ToResponse()
             .FirstOrDefaultAsync(cancellationToken);
 
         if (resource is null)

--- a/apps/api/src/Application/Resources/GetById/GetByIdResource.cs
+++ b/apps/api/src/Application/Resources/GetById/GetByIdResource.cs
@@ -21,24 +21,22 @@ public class GetByIdResourceHandler(IAppDbContext dbContext, CurrentUser current
     /// <returns></returns>
     public async Task<Result<ResourceResponse>> GetByIdAsync(Guid id, CancellationToken cancellationToken)
     {
-        var user = await dbContext.Users
-            .Include(x => x.Resources)
+        var resource = await dbContext.Users
             .Where(x => x.Id == currentUser.Id)
-            .FirstOrDefaultAsync(cancellationToken);
-
-        if (user is null)
-        {
-            logger.LogWarning("User with id '{UserId}' was not found", currentUser.Id);
-            return Error.NotFound("User was not found");
-        }
-
-        var resource = user.Resources
+            .SelectMany(x => x.Resources)
             .Where(x => x.Id == id)
-            .Select(x => new ResourceResponse(x.Id, x.Name, x.Color, x.Unit, x.CreatorType))
-            .FirstOrDefault();
+            .AsNoTracking()
+            .ProjectToResponse()
+            .FirstOrDefaultAsync(cancellationToken);
 
         if (resource is null)
         {
+            if (!await dbContext.Users.AnyAsync(x => x.Id == currentUser.Id, cancellationToken))
+            {
+                logger.LogWarning("User with id '{UserId}' was not found", currentUser.Id);
+                return Error.NotFound("User was not found");
+            }
+
             return Error.NotFound($"Resource with id '{id}' was not found");
         }
 

--- a/apps/api/src/Application/Resources/Shared/ResponseMapper.cs
+++ b/apps/api/src/Application/Resources/Shared/ResponseMapper.cs
@@ -1,0 +1,25 @@
+using Kijk.Domain.Entities;
+using Riok.Mapperly.Abstractions;
+
+namespace Kijk.Application.Resources.Shared;
+
+/// <summary>
+/// Maps resource entities to API responses.
+/// </summary>
+[Mapper(RequiredMappingStrategy = RequiredMappingStrategy.Target)]
+public static partial class ResourceResponseMapper
+{
+    /// <summary>
+    /// Maps a materialized resource entity to a response.
+    /// </summary>
+    /// <param name="source">The resource to map.</param>
+    /// <returns>The mapped response.</returns>
+    public static partial ResourceResponse ToResponse(this Resource source);
+
+    /// <summary>
+    /// Projects resource entities to responses in the underlying query provider.
+    /// </summary>
+    /// <param name="source">The resource query.</param>
+    /// <returns>The projected response query.</returns>
+    public static partial IQueryable<ResourceResponse> ProjectToResponse(this IQueryable<Resource> source);
+}

--- a/apps/api/src/Application/Resources/Shared/ResponseMapper.cs
+++ b/apps/api/src/Application/Resources/Shared/ResponseMapper.cs
@@ -21,5 +21,5 @@ public static partial class ResourceResponseMapper
     /// </summary>
     /// <param name="source">The resource query.</param>
     /// <returns>The projected response query.</returns>
-    public static partial IQueryable<ResourceResponse> ProjectToResponse(this IQueryable<Resource> source);
+    public static partial IQueryable<ResourceResponse> ToResponse(this IQueryable<Resource> source);
 }

--- a/apps/api/src/Application/Resources/Update/UpdateResource.cs
+++ b/apps/api/src/Application/Resources/Update/UpdateResource.cs
@@ -36,12 +36,6 @@ public class UpdateResourceHandler(IAppDbContext dbContext, CurrentUser currentU
 
         await dbContext.SaveChangesAsync(cancellationToken);
 
-        return new ResourceResponse(
-            resource.Id,
-            resource.Name,
-            resource.Color,
-            resource.Unit,
-            resource.CreatorType
-        );
+        return resource.ToResponse();
     }
 }

--- a/apps/api/src/Application/Users/GetMe/GetMeUser.cs
+++ b/apps/api/src/Application/Users/GetMe/GetMeUser.cs
@@ -16,7 +16,7 @@ public class GetMeUserHandler(IAppDbContext dbContext, CurrentUser currentUser, 
             .Where(x => x.Id == currentUser.Id)
             .AsNoTracking()
             .AsSplitQuery()
-            .ProjectToResponse()
+            .ToResponse()
             .FirstOrDefaultAsync(cancellationToken);
 
         if (userEntity is null)

--- a/apps/api/src/Application/Users/GetMe/GetMeUser.cs
+++ b/apps/api/src/Application/Users/GetMe/GetMeUser.cs
@@ -13,14 +13,10 @@ public class GetMeUserHandler(IAppDbContext dbContext, CurrentUser currentUser, 
     public async Task<Result<GetMeUserResponse>> GetMeAsync(CancellationToken cancellationToken)
     {
         var userEntity = await dbContext.Users
-            .Include(x => x.UserHouseholds)
-            .ThenInclude(x => x.Household)
-            .Include(x => x.UserHouseholds)
-            .ThenInclude(x => x.Role)
-            .ThenInclude(x => x.Permissions)
             .Where(x => x.Id == currentUser.Id)
             .AsNoTracking()
             .AsSplitQuery()
+            .ProjectToResponse()
             .FirstOrDefaultAsync(cancellationToken);
 
         if (userEntity is null)
@@ -29,13 +25,6 @@ public class GetMeUserHandler(IAppDbContext dbContext, CurrentUser currentUser, 
             return Error.NotFound("User not found");
         }
 
-        return new GetMeUserResponse(
-            userEntity.Id,
-            userEntity.AuthId,
-            userEntity.Name,
-            userEntity.Email,
-            userEntity.FirstTime,
-            userEntity.UserHouseholds.Select(UserHouseholdResponse.Create),
-            userEntity.Resources.Select(c => new UserResourceResponse(c.Id, c.Name, c.Unit, c.Color, c.CreatorType)));
+        return userEntity;
     }
 }

--- a/apps/api/src/Application/Users/GetMe/Response.cs
+++ b/apps/api/src/Application/Users/GetMe/Response.cs
@@ -1,4 +1,3 @@
-using Kijk.Domain.Entities;
 using Kijk.Shared;
 
 namespace Kijk.Application.Users.GetMe;
@@ -12,16 +11,8 @@ public record GetMeUserResponse(
     IEnumerable<UserHouseholdResponse>? Households,
     IEnumerable<UserResourceResponse>? Resources);
 
-public record UserHouseholdResponse(Guid Id, string Name, string? Description, UserHouseholdRoleResponse Role, bool IsActive)
-{
-    public static UserHouseholdResponse Create(UserHousehold userHousehold) =>
-        new(userHousehold.Id, userHousehold.Household.Name, userHousehold.Household.Description, UserHouseholdRoleResponse.Create(userHousehold.Role),
-            userHousehold.IsActive);
-}
+public record UserHouseholdResponse(Guid Id, string Name, string? Description, UserHouseholdRoleResponse Role, bool IsActive);
 
-public record UserHouseholdRoleResponse(Guid Id, string Name, IList<string> Permissions)
-{
-    public static UserHouseholdRoleResponse Create(Role role) => new(role.Id, role.Name, [.. role.Permissions.Select(x => x.Name)]);
-}
+public record UserHouseholdRoleResponse(Guid Id, string Name, IList<string> Permissions);
 
 public record UserResourceResponse(Guid Id, string Name, string Unit, string Color, CreatorType CreatorType);

--- a/apps/api/src/Application/Users/GetMe/ResponseMapper.cs
+++ b/apps/api/src/Application/Users/GetMe/ResponseMapper.cs
@@ -1,0 +1,27 @@
+using Kijk.Domain.Entities;
+using Riok.Mapperly.Abstractions;
+
+namespace Kijk.Application.Users.GetMe;
+
+/// <summary>
+/// Projects user entities to detailed current-user responses.
+/// </summary>
+[Mapper(RequiredMappingStrategy = RequiredMappingStrategy.Target)]
+public static partial class GetMeUserResponseMapper
+{
+    /// <summary>
+    /// Projects user entities to detailed responses in the underlying query provider.
+    /// </summary>
+    /// <param name="source">The user query.</param>
+    /// <returns>The projected response query.</returns>
+    public static partial IQueryable<GetMeUserResponse> ProjectToResponse(this IQueryable<User> source);
+
+    [MapProperty(nameof(User.UserHouseholds), nameof(GetMeUserResponse.Households))]
+    private static partial GetMeUserResponse Map(User source);
+
+    [MapProperty(nameof(UserHousehold.Household.Name), nameof(UserHouseholdResponse.Name))]
+    [MapProperty(nameof(UserHousehold.Household.Description), nameof(UserHouseholdResponse.Description))]
+    private static partial UserHouseholdResponse MapHousehold(UserHousehold source);
+
+    private static string MapPermission(Permission source) => source.Name;
+}

--- a/apps/api/src/Application/Users/GetMe/ResponseMapper.cs
+++ b/apps/api/src/Application/Users/GetMe/ResponseMapper.cs
@@ -14,7 +14,7 @@ public static partial class GetMeUserResponseMapper
     /// </summary>
     /// <param name="source">The user query.</param>
     /// <returns>The projected response query.</returns>
-    public static partial IQueryable<GetMeUserResponse> ProjectToResponse(this IQueryable<User> source);
+    public static partial IQueryable<GetMeUserResponse> ToResponse(this IQueryable<User> source);
 
     [MapProperty(nameof(User.UserHouseholds), nameof(GetMeUserResponse.Households))]
     private static partial GetMeUserResponse Map(User source);

--- a/apps/api/src/Application/Users/Shared/ResponseMapper.cs
+++ b/apps/api/src/Application/Users/Shared/ResponseMapper.cs
@@ -23,7 +23,7 @@ public static partial class UserResponseMapper
     /// </summary>
     /// <param name="source">The user query.</param>
     /// <returns>The projected response query.</returns>
-    public static partial IQueryable<UserResponse> ProjectToResponse(this IQueryable<User> source);
+    public static partial IQueryable<UserResponse> ToResponse(this IQueryable<User> source);
 
     [MapPropertyFromSource(nameof(UserResponse.UseDefaultResources), Use = nameof(MapUseDefaultResources))]
     private static partial UserResponse Map(User source);

--- a/apps/api/src/Application/Users/Shared/ResponseMapper.cs
+++ b/apps/api/src/Application/Users/Shared/ResponseMapper.cs
@@ -1,0 +1,33 @@
+using Kijk.Domain.Entities;
+using Kijk.Shared;
+using Riok.Mapperly.Abstractions;
+
+namespace Kijk.Application.Users.Shared;
+
+/// <summary>
+/// Maps user entities to API responses.
+/// </summary>
+[Mapper(RequiredMappingStrategy = RequiredMappingStrategy.Target)]
+public static partial class UserResponseMapper
+{
+    /// <summary>
+    /// Maps a materialized user entity to a response.
+    /// </summary>
+    /// <param name="source">The user to map.</param>
+    /// <param name="useDefaultResources">Whether the response should indicate that default resources are used.</param>
+    /// <returns>The mapped response.</returns>
+    public static partial UserResponse ToResponse(this User source, bool useDefaultResources);
+
+    /// <summary>
+    /// Projects user entities to responses in the underlying query provider.
+    /// </summary>
+    /// <param name="source">The user query.</param>
+    /// <returns>The projected response query.</returns>
+    public static partial IQueryable<UserResponse> ProjectToResponse(this IQueryable<User> source);
+
+    [MapPropertyFromSource(nameof(UserResponse.UseDefaultResources), Use = nameof(MapUseDefaultResources))]
+    private static partial UserResponse Map(User source);
+
+    private static bool? MapUseDefaultResources(User source) =>
+        source.Resources.Any(resource => resource.CreatorType == CreatorType.System);
+}

--- a/apps/api/src/Application/Users/SignIn/SignInUser.cs
+++ b/apps/api/src/Application/Users/SignIn/SignInUser.cs
@@ -1,9 +1,9 @@
 ﻿using System.Security.Cryptography;
 using Kijk.Application.Abstractions.Persistence;
+using Kijk.Application.Users.Shared;
 using Kijk.Domain.Entities;
 using Kijk.Shared;
 using Microsoft.Extensions.Logging;
-using UserResponse = Kijk.Application.Users.Shared.UserResponse;
 
 namespace Kijk.Application.Users.SignIn;
 
@@ -38,21 +38,15 @@ public class SignInUserHandler(IAppDbContext dbContext, CurrentUser currentUser,
 
             await dbContext.SaveChangesAsync(cancellationToken);
 
-            return new UserResponse(
-                newUserEntity.Id,
-                newUserEntity.AuthId,
-                newUserEntity.Name,
-                newUserEntity.Email,
-                newUserEntity.FirstTime,
-                newUserEntity.Resources.Any(c => c.CreatorType == CreatorType.User));
+            return newUserEntity.ToResponse(newUserEntity.Resources.Any(resource => resource.CreatorType == CreatorType.User));
         }
 
         await dbContext.SaveChangesAsync(cancellationToken);
 
         var userEntity = await dbContext.Users
             .Where(x => x.Id == currentUser.Id)
-            .Include(x => x.Resources)
             .AsNoTracking()
+            .ProjectToResponse()
             .FirstOrDefaultAsync(cancellationToken);
 
         if (userEntity is null)
@@ -61,16 +55,6 @@ public class SignInUserHandler(IAppDbContext dbContext, CurrentUser currentUser,
             return Error.NotFound("User not found");
         }
 
-        var useDefaultResources = userEntity.Resources.Any(c => c.CreatorType == CreatorType.System);
-
-        var updateUserResponse = new UserResponse(
-            userEntity.Id,
-            userEntity.AuthId,
-            userEntity.Name,
-            userEntity.Email,
-            userEntity.FirstTime,
-            useDefaultResources);
-
-        return updateUserResponse;
+        return userEntity;
     }
 }

--- a/apps/api/src/Application/Users/SignIn/SignInUser.cs
+++ b/apps/api/src/Application/Users/SignIn/SignInUser.cs
@@ -46,7 +46,7 @@ public class SignInUserHandler(IAppDbContext dbContext, CurrentUser currentUser,
         var userEntity = await dbContext.Users
             .Where(x => x.Id == currentUser.Id)
             .AsNoTracking()
-            .ProjectToResponse()
+            .ToResponse()
             .FirstOrDefaultAsync(cancellationToken);
 
         if (userEntity is null)

--- a/apps/api/src/Application/Users/Update/UpdateUser.cs
+++ b/apps/api/src/Application/Users/Update/UpdateUser.cs
@@ -51,12 +51,6 @@ public class UpdateUserHandler(IAppDbContext dbContext, CurrentUser currentUser,
 
         await dbContext.SaveChangesAsync(cancellationToken);
 
-        return new UserResponse(
-            userEntity.Id,
-            userEntity.AuthId,
-            userEntity.Name,
-            userEntity.Email,
-            userEntity.FirstTime,
-            userEntity.Resources.Any(c => c.CreatorType == CreatorType.System));
+        return userEntity.ToResponse(userEntity.Resources.Any(resource => resource.CreatorType == CreatorType.System));
     }
 }

--- a/apps/api/src/Application/Users/Welcome/WelcomeUser.cs
+++ b/apps/api/src/Application/Users/Welcome/WelcomeUser.cs
@@ -1,10 +1,10 @@
 ﻿using Kijk.Application.Abstractions.Persistence;
+using Kijk.Application.Users.Shared;
 using Kijk.Shared;
 using Kijk.Shared.Extensions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.Extensions.Logging;
-using UserResponse = Kijk.Application.Users.Shared.UserResponse;
 
 namespace Kijk.Application.Users.Welcome;
 
@@ -50,12 +50,6 @@ public class WelcomeUserHandler(IAppDbContext dbContext, CurrentUser currentUser
 
         await dbContext.SaveChangesAsync(cancellationToken);
 
-        return new UserResponse(
-            user.Id,
-            user.AuthId,
-            user.Name,
-            user.Email,
-            user.FirstTime,
-            user.Resources.Any(c => c.CreatorType == CreatorType.System));
+        return user.ToResponse(user.Resources.Any(resource => resource.CreatorType == CreatorType.System));
     }
 }

--- a/apps/api/src/Application/Users/Welcome/WelcomeUser.cs
+++ b/apps/api/src/Application/Users/Welcome/WelcomeUser.cs
@@ -1,9 +1,6 @@
 ﻿using Kijk.Application.Abstractions.Persistence;
 using Kijk.Application.Users.Shared;
 using Kijk.Shared;
-using Kijk.Shared.Extensions;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.Extensions.Logging;
 
 namespace Kijk.Application.Users.Welcome;


### PR DESCRIPTION
### Pull Request

Implements [KIJK-317](https://linear.app/justmax/issue/KIJK-317/use-mapperly-for-mapping).

#### Checklist

- [x] Code documented
- [x] Version updated (not applicable for this internal refactor)
- [x] Tests created (not applicable; the solution currently has no API test projects)
- [x] Docs/Readme updated (not applicable; public API usage is unchanged)

#### New Features, Bugfixes and more

- Add Riok.Mapperly 4.3.1 as a compile-time-only dependency for the API and Application projects.
- Introduce target-strict static response mappers for consumptions, resources, users, GetMe, and authenticated users.
- Project suitable read queries directly through EF Core and use object mappings only for already materialized write results.
- Remove duplicated manual response construction and unnecessary entity includes while keeping response contracts unchanged.

#### Developer impact

Mappings are now checked at build time. Adding a response member without mapping it produces a Mapperly diagnostic. Read handlers retrieve only the fields required by their response projections.

#### Validation

- `dotnet build apps/api/Kijk.slnx -c Release --no-restore`
- `dotnet format apps/api/Kijk.slnx --verify-no-changes --exclude '**/Migrations/**'`
- `dotnet test apps/api/Kijk.slnx -c Release --no-build` (no test projects present)
- `git diff --check`
- Generated OpenAPI document unchanged

#### Notes

The package audit still reports the existing transitive high-severity vulnerability in `Microsoft.OpenApi 2.0.0` ([GHSA-v5pm-xwqc-g5wc](https://github.com/advisories/GHSA-v5pm-xwqc-g5wc)). This dependency is unrelated to Mapperly.