### PR TITLE
fix(api): skip current user lookup for public endpoints

### DIFF
--- a/apps/api/src/Api/Mappers/SimpleAuthUserMapper.cs
+++ b/apps/api/src/Api/Mappers/SimpleAuthUserMapper.cs
@@ -2,7 +2,7 @@ using Kijk.Domain.Entities;
 using Kijk.Shared;
 using Riok.Mapperly.Abstractions;
 
-namespace Kijk.Api.Middleware;
+namespace Kijk.Api.Mappers;
 
 /// <summary>
 /// Projects user entities to the authenticated-user representation.

--- a/apps/api/src/Api/Middleware/CurrentUserMiddleware.cs
+++ b/apps/api/src/Api/Middleware/CurrentUserMiddleware.cs
@@ -1,8 +1,10 @@
 ﻿using System.Security.Claims;
 using Kijk.Api.Extensions;
+using Kijk.Api.Mappers;
 using Kijk.Infrastructure.Persistence;
 using Kijk.Infrastructure.Telemetry;
 using Kijk.Shared;
+using Microsoft.AspNetCore.Authorization;
 
 namespace Kijk.Api.Middleware;
 
@@ -17,7 +19,11 @@ public class CurrentUserMiddleware(IProblemDetailsService problemDetailsService,
 {
     public async Task InvokeAsync(HttpContext context, RequestDelegate next)
     {
-        if (context.GetEndpoint() is null)
+        var endpoint = context.GetEndpoint();
+        var isPublicEndpoint = endpoint?.Metadata.GetMetadata<IAuthorizeData>() is null
+            || endpoint.Metadata.GetMetadata<IAllowAnonymous>() is not null;
+
+        if (isPublicEndpoint)
         {
             await next(context);
             return;
@@ -39,15 +45,10 @@ public class CurrentUserMiddleware(IProblemDetailsService problemDetailsService,
 
     private async Task<(bool, string)> SetCurrentUser(HttpContext context)
     {
-        if (context.Request.Path == "/" || AppConstants.AllowedOpenApiPaths.Any(x => context.Request.Path.ToString().Contains(x)))
-        {
-            return (true, string.Empty);
-        }
-
         var extAuthId = context.User.FindFirstValue(ClaimTypes.NameIdentifier);
-        if (extAuthId == null)
+        if (string.IsNullOrWhiteSpace(extAuthId))
         {
-            return (false, $"User for id '{extAuthId}' was not found");
+            return (false, "Current user identifier claim is missing");
         }
 
         var email = context.User.FindFirstValue(ClaimTypes.Email);

--- a/apps/api/src/Shared/AppConstants.cs
+++ b/apps/api/src/Shared/AppConstants.cs
@@ -2,12 +2,6 @@
 
 public static class AppConstants
 {
-    /// <summary>
-    /// These paths are allowed to be accessed without validating the current user.
-    /// It is only used in "CurrentUserMiddleware" to determine if the current user should be set.
-    /// </summary>
-    public static readonly string[] AllowedOpenApiPaths = ["openapi", "scalar", "favicon"];
-
     public const string CreateUserIdentifier = "CREATE_USER";
 
     /// <summary>


### PR DESCRIPTION
## Summary

- resolve the current user only for endpoints that require authorization
- allow health checks, OpenAPI, static assets, anonymous endpoints, and unmatched routes to continue without a user lookup
- reject missing or whitespace-only user identifiers before querying the database
- move `SimpleAuthUserMapper` from the middleware namespace into `Kijk.Api.Mappers`

## Root cause

`CurrentUserMiddleware` ran globally and only skipped requests without a matched endpoint or requests covered by a hard-coded path allowlist. Public endpoints such as `/health` still have endpoint metadata, so the middleware attempted to resolve an unauthenticated user and reported `User for id '' was not found`.

## Impact

Public endpoints no longer perform current-user database lookups or emit misleading authentication telemetry. Protected API endpoints continue to resolve the current user after authentication and authorization.

## Validation

- `dotnet build apps/api/src/Api/Api.csproj -c Release --no-restore --disable-build-servers`
- `dotnet format apps/api/Kijk.slnx --verify-no-changes --no-restore --exclude '**/Migrations/'`
- pre-commit staged API format check
- `git diff --check`

Automated tests are intentionally handled in a separate ticket.

The build retains the existing NU1903 warning for the transitive `Microsoft.OpenApi` 2.0.0 vulnerability.

Linear: [KIJK-336](https://linear.app/justmax/issue/KIJK-336/current-user-lookup-fails-when-user-id-is-empty)